### PR TITLE
Add composer.json to be able to use Composer to fetch the SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "ooyala/php-v2-sdk",
+    "description": "The PHP SDK is a client class for our V2 API.",
+    "authors": [
+        {
+            "name": "Ooyala"
+        }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -5,5 +5,11 @@
         {
             "name": "Ooyala"
         }
-    ]
+    ],
+    "autoload": {
+        "psr-0": {
+            "Ooyala": "/",
+            "Ooyala\\Tests": "test/"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,5 @@
         {
             "name": "Ooyala"
         }
-    ],
-    "autoload": {
-        "psr-0": {
-            "Ooyala": "/",
-            "Ooyala\\Tests": "test/"
-        }
-    }
+    ]
 }


### PR DESCRIPTION
If somebody wants to use *Composer* to fetch the SDK, ```composer.json``` file is required to make it work. 
You can change values of *description* and *authors* as you wish of course.