### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "ooyala/v2-api",
+    "description": "Ooyala's V2 API PHP SDK",
+    "license": "proprietary",
+    "autoload": {
+        "files": ["OoyalaApi.php"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}


### PR DESCRIPTION
This is similar to #2 but uses the files autoload strategy. I think this is more appropriate. It also ignores the tests and uses a branch alias for 1.0.\* for the master branch.

Another way to handle this would be to name this package "ooyala/api" and setup the branch alias to 2.0.x-dev instead so that master would represent 2.0.*.

However, since the repository name has php-v2-sdk in its name I went with the path of naming the actual package "v2-api" and opting to consider the v2 api to be versioned differently.

I'm happy to change this to whatever you'd like to see.
